### PR TITLE
bugfix: npx codeandpepper/janush

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -7,7 +7,6 @@ exports.cli = void 0;
 const path_1 = __importDefault(require("path"));
 const arg_1 = __importDefault(require("arg"));
 const child_process_1 = require("child_process");
-const PATH_ARGUMENT = 1;
 const PATH_ARGS = 2;
 const COMMAND = "command";
 const SKIP_INSTALL = "skipInstall";
@@ -53,17 +52,8 @@ function encodeCommand(command, options) {
     }, command);
 }
 function cli(args) {
-    let directory;
-    if (__dirname.includes("@")) {
-        //INFO: npx via github
-        directory = `@${path_1.default.join(__dirname, "..").split("@")[PATH_ARGUMENT]}`;
-    }
-    else {
-        //INFO: installed project
-        directory = path_1.default.join(__dirname, "..");
-    }
     const options = parseArgumentsIntoOptions(args);
-    child_process_1.spawn(encodeCommand(`schematics ${directory}/schematics/collection.json:${options.command}`, options), {
+    child_process_1.spawn(encodeCommand(`schematics ${path_1.default.join(__dirname, "..")}/schematics/collection.json:${options.command}`, options), {
         stdio: "inherit",
         shell: true,
     });

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -2,7 +2,6 @@ import path from "path";
 import arg from "arg";
 import { spawn } from "child_process";
 
-const PATH_ARGUMENT = 1;
 const PATH_ARGS = 2;
 const COMMAND = "command";
 const SKIP_INSTALL = "skipInstall";
@@ -66,21 +65,13 @@ function encodeCommand(command: string, options: Options) {
 }
 
 export function cli(args: string[]) {
-  let directory;
-
-  if (__dirname.includes("@")) {
-    //INFO: npx via github
-    directory = `@${path.join(__dirname, "..").split("@")[PATH_ARGUMENT]}`;
-  } else {
-    //INFO: installed project
-    directory = path.join(__dirname, "..");
-  }
-
   const options = parseArgumentsIntoOptions(args);
 
   spawn(
     encodeCommand(
-      `schematics ${directory}/schematics/collection.json:${options.command}`,
+      `schematics ${path.join(__dirname, "..")}/schematics/collection.json:${
+        options.command
+      }`,
       options
     ),
     {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "node": "14.x.x"
   },
   "scripts": {
+    "prepare": "npm run build",
     "build": "tsc && tsc-alias --silent",
     "test": "jest",
     "test:watch": "npm run build && jest --watch --no-cache",
@@ -35,6 +36,7 @@
     "esm": "^3.2.25",
     "lodash.isempty": "^4.4.0",
     "lodash.xor": "^4.5.0",
+    "prettier": "^2.3.2",
     "typescript": "~4.3.2"
   },
   "devDependencies": {
@@ -44,7 +46,6 @@
     "@types/node": "^16.10.1",
     "@types/prettier": "^2.3.2",
     "jest": "^27.4.5",
-    "prettier": "^2.3.2",
     "ts-jest": "^27.1.1",
     "tsc-alias": "^1.3.9"
   }


### PR DESCRIPTION
It seems that [correct package.json](https://github.com/codeandpepper/janush/pull/88) was not the only dependency required to make `npx codeandpepper/janush` work correctly.

As @arkjel pinged me with the problems he have I've decided to make an investigation again. [It seemed that locally linked `janush` has been used by `npx` script and I've missed it.](https://stackoverflow.com/questions/50804356/does-npx-look-for-globally-installed-packages)

What has been changed?

- `cli.ts` `directory` conditional statements (previously process has been crashing, as script was not able to resolve the output path)
- `prepare` script is running `npm run build`. There was no chance to make `npx codeandpepper/janush` work for the end user, as all `js` files are listed in `.gitignore` and all `ts` files are listed in `.npmignore`. It has been causing lack of any script files in the end user installation process (this happened for example during @arkjel work)
- `prettier` has been moved from `devDependencies` to `dependencies`, as it is normally running in a built `janush` app

If you'd like to test for sure if it works okay, please run `npx codeandpepper/janush#bugfix/npx-build-fix` command. 

EDIT: @arkjel confirmed, that this fix works for him