### PR TITLE
Bugfix/janush cli schematics 3

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -9,6 +9,8 @@ const arg_1 = __importDefault(require("arg"));
 const child_process_1 = require("child_process");
 const PATH_ARGS = 2;
 const COMMAND = "command";
+const SCHEMATICS_CLI_PATH = path_1.default.join(__dirname, "..", "node_modules", "@angular-devkit", "schematics-cli", "bin", "schematics.js");
+const SCHEMATICS_COLLECTION_PATH = path_1.default.join(__dirname, "..", "schematics", "collection.json");
 function parseArgumentsIntoOptions(rawArgs) {
     const args = arg_1.default({
         "--command": String,
@@ -59,7 +61,7 @@ function encodeCommand(command, options) {
 }
 function cli(args) {
     const options = parseArgumentsIntoOptions(args);
-    child_process_1.spawn(encodeCommand(`schematics ${path_1.default.join(__dirname, "..")}/schematics/collection.json:${options.command}`, options), {
+    child_process_1.spawn(encodeCommand(`${SCHEMATICS_CLI_PATH} ${SCHEMATICS_COLLECTION_PATH}:${options.command}`, options), {
         stdio: "inherit",
         shell: true,
     });

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -4,6 +4,21 @@ import { spawn } from "child_process";
 
 const PATH_ARGS = 2;
 const COMMAND = "command";
+const SCHEMATICS_CLI_PATH = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "@angular-devkit",
+  "schematics-cli",
+  "bin",
+  "schematics.js"
+);
+const SCHEMATICS_COLLECTION_PATH = path.join(
+  __dirname,
+  "..",
+  "schematics",
+  "collection.json"
+);
 
 interface Options {
   //INFO: Change 'command' to more suitable name for schematics' type
@@ -81,9 +96,7 @@ export function cli(args: string[]) {
 
   spawn(
     encodeCommand(
-      `schematics ${path.join(__dirname, "..")}/schematics/collection.json:${
-        options.command
-      }`,
+      `${SCHEMATICS_CLI_PATH} ${SCHEMATICS_COLLECTION_PATH}:${options.command}`,
       options
     ),
     {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@angular-devkit/core": "^12.2.4",
     "@angular-devkit/schematics": "^12.2.4",
+    "@angular-devkit/schematics-cli": "^13.1.2",
     "@schematics/angular": "^12.2.4",
     "arg": "^5.0.1",
     "esm": "^3.2.25",


### PR DESCRIPTION
Bugfix - for `schematics: not found` error on not having `@angular-devkit/schematics-cli` package installed globally.
Resolved by using internal schematics cli package execution instead of the global command name.